### PR TITLE
Attempt to fix autocomplete for strings that start with "$"

### DIFF
--- a/src/com/alchitry/labs/style/AutoComplete.java
+++ b/src/com/alchitry/labs/style/AutoComplete.java
@@ -107,7 +107,10 @@ public class AutoComplete {
         int start, end;
         end = Math.min(editor.getCaretOffset(), text.length());
         start = Math.max(end - 1, 0);
-        while (start > 0 && (Character.isLetterOrDigit(text.charAt(start)) || text.charAt(start) == '_'))
+        while (start > 0 && (Character.isLetterOrDigit(text.charAt(start))
+                || text.charAt(start) == '_'
+                || text.charAt(start) == '$')
+        )
             start--;
         start++;
         if (start > end)


### PR DESCRIPTION
### Please review as I was not able to successfully build due to issue unrelated to this code

When typing out variables in the IDE that start with `$`, for example `$clog`, autocomplete will correctly suggest possibilities, but when replacing the variable it will not properly identify the start as `$` and will replace the text creating a double first character: `$$clog`.

I was not able to get the IDE to build from the current code. IntelliJ was not happy with it and gave lots of errors when trying to build. A pom.xml or other build manifest would be helpful for this. 

I did do some testing to compare `Character.isLetterOrDigit` to `text.charAt(start) == '$'` in the console:
```java
String text = "$clog";
System.out.println(Character.isLetterOrDigit(text.charAt(0)));
System.out.println(text.charAt(0) == '$');
```
```
Defined field String text = "$clog"

System.out.println(Character.isLetterOrDigit(text.charAt(0)))
false

System.out.println(text.charAt(0) == '$')
true
```

Considering that there was already an exception for text that starts with `_`, I hope that an additional check for `$` will fix this issue. If it will not, please reject this PR. I may have misunderstood why the additional check for `_` is required. 